### PR TITLE
Use only major version

### DIFF
--- a/linux/makes/gcc
+++ b/linux/makes/gcc
@@ -61,10 +61,11 @@ cd gcc-build
     --enable-multilib \
     --enable-multiarch \
     --prefix=/usr/local/raspbian10-toolchain \
+    --with-gcc-major-version-only \
     --with-sysroot=/usr/local/raspbian10-toolchain/sys-root \
     --disable-libmudflap \
     --libdir=/usr/local/raspbian10-toolchain/sys-root/usr/lib \
-    --with-gxx-include-dir=/usr/local/raspbian10-toolchain/sys-root/usr/include/c++/8.3.0 \
+    --with-gxx-include-dir=/usr/local/raspbian10-toolchain/sys-root/usr/include/c++/8 \
     --with-system-zlib \
     || exit $?
 make -j3 all-gcc || exit $?

--- a/mac/makes/gcc
+++ b/mac/makes/gcc
@@ -61,10 +61,11 @@ cd gcc-build
     --enable-multilib \
     --enable-multiarch \
     --prefix=/usr/local/raspbian10-toolchain \
+    --with-gcc-major-version-only \
     --with-sysroot=/usr/local/raspbian10-toolchain/sys-root \
     --disable-libmudflap \
     --libdir=/usr/local/raspbian10-toolchain/sys-root/usr/lib \
-    --with-gxx-include-dir=/usr/local/raspbian10-toolchain/sys-root/usr/include/c++/8.3.0 \
+    --with-gxx-include-dir=/usr/local/raspbian10-toolchain/sys-root/usr/include/c++/8 \
     --with-system-zlib \
     || exit $?
 make -j3 all-gcc || exit $?

--- a/repack.sh
+++ b/repack.sh
@@ -44,14 +44,6 @@ rm -rf repack/out/etc
 # remove all empty dirs (semi-recursive)
 rm -d repack/out/*(/^F)
 
-# move "6" to "8.3.0" directories
-#rm repack/out/usr/lib/gcc/arm-linux-gnueabihf/8.3.0
-mv repack/out/usr/lib/gcc/arm-linux-gnueabihf/8 repack/out/usr/lib/gcc/arm-linux-gnueabihf/8.3.0
-rm repack/out/usr/include/arm-linux-gnueabihf/c++/8.3.0
-mv repack/out/usr/include/arm-linux-gnueabihf/c++/8 repack/out/usr/include/arm-linux-gnueabihf/c++/8.3.0
-rm repack/out/usr/include/c++/8.3.0
-mv repack/out/usr/include/c++/8 repack/out/usr/include/c++/8.3.0
-
 # change absolute symlinks into relative symlinks
 pushd repack/out/usr/lib/arm-linux-gnueabihf
 rm libanl.so
@@ -90,7 +82,7 @@ ln -s ../../../lib/arm-linux-gnueabihf/libthread_db.so.1 libthread_db.so
 ln -s ../../../lib/arm-linux-gnueabihf/libutil.so.1 libutil.so
 popd
 
-pushd repack/out/usr/lib/gcc/arm-linux-gnueabihf/8.3.0
+pushd repack/out/usr/lib/gcc/arm-linux-gnueabihf/8
 rm libasan.so
 rm libatomic.so
 rm libgcc_s.so.1

--- a/windows/makes/gcc
+++ b/windows/makes/gcc
@@ -75,11 +75,12 @@ cd gcc-build
     --enable-multilib \
     --enable-multiarch \
     --prefix=/c/Users/Public/raspbian10 \
+    --with-gcc-major-version-only \
     --with-sysroot=/c/Users/Public/raspbian10/sys-root \
     --disable-libmudflap \
     --with-build-sysroot=/usr/local/raspbian10-toolchain/sys-root \
     --libdir=/c/Users/Public/raspbian10/sys-root/usr/lib \
-    --with-gxx-include-dir=/c/Users/Public/raspbian10/sys-root/usr/include/c++/8.3.0 \
+    --with-gxx-include-dir=/c/Users/Public/raspbian10/sys-root/usr/include/c++/8 \
     || exit $?
 make -j3 all-gcc || exit $?
 DESTDIR=$PWD/../gcc-install make install-gcc || exit $?


### PR DESCRIPTION
On debian-based systems, GCC 8 and later only use the major version.